### PR TITLE
Add benchmark configs for each model/workload pair

### DIFF
--- a/experiments/e2e_goodput/equal_model_exp.py
+++ b/experiments/e2e_goodput/equal_model_exp.py
@@ -2,8 +2,9 @@ import argparse
 import os
 from datetime import datetime
 
-from benchmarks.alpa.equal_model_case import EqualModelCase, run_equal_model_cases
 from alpa_serve.util import GB
+from benchmarks.alpa.equal_model_case import EqualModelCase, run_equal_model_cases
+from equal_model_suite import synthetic_suite, azure_v1_suite, azure_v2_suite
 
 
 if __name__ == "__main__":
@@ -18,9 +19,13 @@ if __name__ == "__main__":
                         choices=["all", "goodput_vs_num_devices", "goodput_vs_num_models",
                               "goodput_vs_slo", "goodput_vs_rate", "goodput_vs_cv",
                               "num_devices_vs_num_models"])
-    parser.add_argument("--synthetic", action="store_true")
+    parser.add_argument("--model_type", type=str, default="bert-1.3b",
+                        choices=["bert-1.3b", "bert-2.6b", "bert-6.7b"])
+    parser.add_argument("--mem_budget", type=int, default=14)
+    parser.add_argument("--workload", type=str, default="synthetic",
+                        choices=["synthetic", "azure_v1", "azure_v2"])
     parser.add_argument("--rate-distribution", choices=["uniform", "power_law"],
-                        default="uniform")
+                        default="power_law")
     parser.add_argument("--rate", type=float, default=64)
     parser.add_argument("--cv", type=float, default=4)
     parser.add_argument('--duration', type=float, default=200)
@@ -28,9 +33,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # choices: {"sr-greedy", "sr-ilp", "mp-ilp", "mp-greedy-2", "mp-greedy-8"}
-    policies = ["sr-search", "mp-search"]
-    mem_budget = 16 * GB
-    model_type = "bert-2.6b"
+    policies = ["sr-greedy", "mp-search"]
+    mem_budget = args.mem_budget * GB
+    model_type = args.model_type
 
     # default config
     fixed_num_devices = 32
@@ -40,14 +45,29 @@ if __name__ == "__main__":
     fixed_slo_scale = 5
 
     # workload config
-    if args.synthetic:
+    if args.workload == "synthetic":
         rate_distribution = args.rate_distribution
         total_rate = args.rate
         duration = args.duration
 
         arrival_process = "gamma"
         arrival_process_kwargs = {"cv": args.cv}
-    else:
+
+        num_devices_list, num_models_list, slo_scales, \
+        rate_list, cv_list, rate_scales, cv_scales = synthetic_suite[model_type]
+    elif args.workload == "azure_v1":
+        # real trace does not need these config
+        rate_distribution = None
+        total_rate = -1
+        duration = -1
+
+        arrival_process = "azure_v1"
+        arrival_process_kwargs = {"rate_scale": fixed_rate_scale,
+                                  "cv_scale": fixed_cv_scale,
+                                  "trace_dir": args.trace_dir}
+        num_devices_list, num_models_list, slo_scales, \
+        rate_list, cv_list, rate_scales, cv_scales = azure_v1_suite[model_type]
+    elif args.workload == "azure_v2":
         # real trace does not need these config
         rate_distribution = None
         total_rate = -1
@@ -55,18 +75,14 @@ if __name__ == "__main__":
 
         arrival_process = "azure_v2"
         arrival_process_kwargs = {"rate_scale": fixed_rate_scale,
-                                "cv_scale": fixed_cv_scale,
-                                "trace_dir": args.trace_dir}
+                                  "cv_scale": fixed_cv_scale,
+                                  "trace_dir": args.trace_dir}
+        num_devices_list, num_models_list, slo_scales, \
+        rate_list, cv_list, rate_scales, cv_scales = azure_v2_suite[model_type]
+    else:
+        raise ValueError("Unsupported workload!")
 
-    # variables
-    num_devices_list = [8, 16, 24, 32, 48, 64, 96, 128]
-    num_models_list = [4, 8, 16, 32, 64, 80, 96]
-    rate_list = [16, 32, 48, 64, 80] # synthetic trace only
-    cv_list = [1, 2, 4, 8]           # synthetic trace only
-    rate_scales = [1, 2, 4, 8, 16]   # real trace only
-    cv_scales = [1, 2, 4, 8, 16]     # real trace only
-    slo_scales = [2.5, 5, 10, 20]
-
+    # output file
     if args.output.endswith(".tsv"):
         output_file_name = args.output
     else:
@@ -114,7 +130,7 @@ if __name__ == "__main__":
             for policy_name in policies:
                 # Note(Hao): we need to scale the rate as well to keep the total traffic unchanged.
                 # when num_model = fix_num_models / 4, the total cluster rate is 1 q/s.
-                if args.synthetic:
+                if args.workload == "synthetic":
                     cases.append(EqualModelCase(
                         fixed_num_devices, mem_budget, model_type, num_models,
                         total_rate * num_models / fixed_num_models, rate_distribution,
@@ -152,7 +168,7 @@ if __name__ == "__main__":
 
     #### goodput vs rate/rate_scale #####
     if "goodput_vs_rate" in experiments:
-        if args.synthetic:
+        if args.workload == "synthetic":
             print("=== Running goodput vs. rate ===")
             cases = []
             for new_rate in rate_list:
@@ -186,7 +202,7 @@ if __name__ == "__main__":
 
     #### goodput vs cv/cv_scale #####
     if "goodput_vs_cv" in experiments:
-        if args.synthetic:
+        if args.workload == "synthetic":
             print("=== Running goodput vs. cv ===")
             cases = []
             for new_cv in cv_list:
@@ -219,37 +235,37 @@ if __name__ == "__main__":
                                 output_file=output_file,
                                 mode=args.mode, parallel=args.parallel)
 
-    ### model vs devices ###
-    if "num_devices_vs_num_models" in experiments:
-        print("=== Running #devices vs. #models ===")
-        cases = []
+    # ### model vs devices ###
+    # if "num_devices_vs_num_models" in experiments:
+    #     print("=== Running #devices vs. #models ===")
+    #     cases = []
 
-        # We need more data points to generate a meaningful curve.
-        num_devices_list = [i for i in range(2, 65, 4)]
-        num_models_list = [i for i in range(8, 97, 2)]
+    #     # We need more data points to generate a meaningful curve.
+    #     num_devices_list = [i for i in range(2, 65, 4)]
+    #     num_models_list = [i for i in range(8, 97, 2)]
 
-        for num_models in num_models_list:
-            for num_devices in num_devices_list:
-                if "1.3b" in model_type or "2.6b" in model_type:
-                    if num_devices * 2 > num_models:
-                        print(f"Skip the case num_devices = {num_devices} and num_models = {num_models} "
-                              f"because the goodput will likely be 100%.")
-                        continue
-                model_size = float(model_type.split("-")[-1][:-1]) * 2
-                if mem_budget / GB * num_devices < model_size * num_models * 2 / 3:
-                    print(f"Skip the case num_devices = {num_devices} and num_models = {num_models} "
-                          f"because the goodput will be less than 66%.")
+    #     for num_models in num_models_list:
+    #         for num_devices in num_devices_list:
+    #             if "1.3b" in model_type or "2.6b" in model_type:
+    #                 if num_devices * 2 > num_models:
+    #                     print(f"Skip the case num_devices = {num_devices} and num_models = {num_models} "
+    #                           f"because the goodput will likely be 100%.")
+    #                     continue
+    #             model_size = float(model_type.split("-")[-1][:-1]) * 2
+    #             if mem_budget / GB * num_devices < model_size * num_models * 2 / 3:
+    #                 print(f"Skip the case num_devices = {num_devices} and num_models = {num_models} "
+    #                       f"because the goodput will be less than 66%.")
 
-                for policy_name in policies:
-                    new_arrival_process_kwargs = {"rate_scale": num_models / fixed_num_models * 4,
-                                              "cv_scale": fixed_cv_scale,
-                                              "trace_dir": args.trace_dir}
-                    cases.append(EqualModelCase(
-                        num_devices, mem_budget, model_type, num_models,
-                        total_rate, rate_distribution,
-                        arrival_process, new_arrival_process_kwargs,
-                        fixed_slo_scale, duration, policy_name))
+    #             for policy_name in policies:
+    #                 new_arrival_process_kwargs = {"rate_scale": num_models / fixed_num_models * 4,
+    #                                           "cv_scale": fixed_cv_scale,
+    #                                           "trace_dir": args.trace_dir}
+    #                 cases.append(EqualModelCase(
+    #                     num_devices, mem_budget, model_type, num_models,
+    #                     total_rate, rate_distribution,
+    #                     arrival_process, new_arrival_process_kwargs,
+    #                     fixed_slo_scale, duration, policy_name))
 
-        run_equal_model_cases(cases, exp_name="num_devices_vs_num_models",
-                              output_file=output_file,
-                              mode=args.mode, parallel=args.parallel)
+    #     run_equal_model_cases(cases, exp_name="num_devices_vs_num_models",
+    #                           output_file=output_file,
+    #                           mode=args.mode, parallel=args.parallel)

--- a/experiments/e2e_goodput/equal_model_suite.py
+++ b/experiments/e2e_goodput/equal_model_suite.py
@@ -1,0 +1,100 @@
+from collections import namedtuple
+
+BenchmarkConfig = namedtuple(
+    "BenchmarkConfig",
+    [
+     "num_devices_list", "num_models_list", "slo_scales",
+     "rate_list", "cv_list", # synthetic trace only
+     "rate_scales", "cv_scales", # real trace only
+    ]
+)
+
+synthetic_suite = {
+    "bert-1.3b": BenchmarkConfig(    
+        num_devices_list = [2, 4, 8, 16, 24, 32, 40],
+        num_models_list = [16, 32, 48, 64, 80, 96],
+        slo_scales = [1, 1.5, 2, 2.5, 4, 5, 6, 7],
+        rate_list = [16, 32, 64, 128, 192, 256, 320, 384],
+        cv_list = [1, 2, 4, 6, 8, 10, 12],
+        rate_scales = [1, 2, 4, 8, 16],
+        cv_scales = [1, 2, 4, 8, 16],
+    ),
+    "bert-2.6b": BenchmarkConfig(    
+        num_devices_list = [8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
+        num_models_list = [4, 8, 16, 24, 32, 40, 48, 56, 64],
+        slo_scales = [1, 1.5, 2, 2.5, 3, 3.5, 4, 6, 8, 10, 12, 14, 16],
+        rate_list = [1, 4, 8, 16, 24, 32, 64, 96, 128, 160, 192],
+        cv_list = [1, 2, 4, 6, 8],
+        rate_scales = [1, 2, 4, 8, 16],
+        cv_scales = [1, 2, 4, 8, 16],
+    ),
+    "bert-6.7b": BenchmarkConfig(    
+        num_devices_list = [24, 32, 40, 56, 72, 88, 104, 120, 136, 152, 168, 184],
+        num_models_list = [2, 4, 6, 8, 12, 16, 24, 32],
+        slo_scales = [5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100],
+        rate_list = [1, 2, 3, 4, 8, 12, 16, 20],
+        cv_list = [0.2, 0.5, 1, 2, 3, 4],
+        rate_scales = [1, 2, 4, 8, 16],
+        cv_scales = [1, 2, 4, 8, 16],
+    ),
+}
+
+azure_v1_suite = {
+    "bert-1.3b": BenchmarkConfig(    
+        num_devices_list = [8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
+        num_models_list = [4, 8, 16, 32, 64, 80, 96],
+        slo_scales = [1, 1.5, 2, 2.5, 5, 7.5, 10, 12.5],
+        rate_list = [8, 16, 32, 64, 96, 128, 160, 192],
+        cv_list = [1, 2, 4, 6, 8],
+        rate_scales = [1, 2, 4, 8, 16],
+        cv_scales = [1, 2, 4, 8, 16],
+    ),
+    "bert-2.6b": BenchmarkConfig(    
+        num_devices_list = [8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
+        num_models_list = [4, 8, 16, 32, 64, 80, 96],
+        slo_scales = [1, 1.5, 2, 2.5, 5, 7.5, 10, 12.5],
+        rate_list = [8, 16, 32, 64, 96, 128, 160, 192],
+        cv_list = [1, 2, 4, 6, 8],
+        rate_scales = [1, 2, 4, 8, 16],
+        cv_scales = [1, 2, 4, 8, 16],
+    ),
+    "bert-6.7b": BenchmarkConfig(    
+        num_devices_list = [8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
+        num_models_list = [4, 8, 16, 32, 64, 80, 96],
+        slo_scales = [1, 1.5, 2, 2.5, 5, 7.5, 10, 12.5],
+        rate_list = [8, 16, 32, 64, 96, 128, 160, 192],
+        cv_list = [1, 2, 4, 6, 8],
+        rate_scales = [1, 2, 4, 8, 16],
+        cv_scales = [1, 2, 4, 8, 16],
+    ),
+}
+
+azure_v2_suite = {
+    "bert-1.3b": BenchmarkConfig(    
+        num_devices_list = [8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
+        num_models_list = [4, 8, 16, 32, 64, 80, 96],
+        slo_scales = [1, 1.5, 2, 2.5, 5, 7.5, 10, 12.5],
+        rate_list = [8, 16, 32, 64, 96, 128, 160, 192],
+        cv_list = [1, 2, 4, 6, 8],
+        rate_scales = [1, 2, 4, 8, 16],
+        cv_scales = [1, 2, 4, 8, 16],
+    ),
+    "bert-2.6b": BenchmarkConfig(    
+        num_devices_list = [8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
+        num_models_list = [4, 8, 16, 32, 64, 80, 96],
+        slo_scales = [1, 1.5, 2, 2.5, 5, 7.5, 10, 12.5],
+        rate_list = [8, 16, 32, 64, 96, 128, 160, 192],
+        cv_list = [1, 2, 4, 6, 8],
+        rate_scales = [1, 2, 4, 8, 16],
+        cv_scales = [1, 2, 4, 8, 16],
+    ),
+    "bert-6.7b": BenchmarkConfig(    
+        num_devices_list = [8, 16, 24, 32, 40, 48, 56, 64, 72, 80],
+        num_models_list = [4, 8, 16, 32, 64, 80, 96],
+        slo_scales = [1, 1.5, 2, 2.5, 5, 7.5, 10, 12.5],
+        rate_list = [8, 16, 32, 64, 96, 128, 160, 192],
+        cv_list = [1, 2, 4, 6, 8],
+        rate_scales = [1, 2, 4, 8, 16],
+        cv_scales = [1, 2, 4, 8, 16],
+    ),
+}


### PR DESCRIPTION
For each model -- workload pair, we need to find suitable benchmark configs (num_devices_list, num_models_list, slo_scale_list, rate_list, cv_list, rate_scale_list, cv_scale_list) to easily show the benefit of our system. For example, `bert-1.3b`'s num_devices_list should focus on smaller num_devices compared to bert-6.7b's, or the goodput_vs_num_devices figure for `bert-1.3b` will only contain goodput=1 points. 